### PR TITLE
Feature/contacts pagination

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,6 +4,7 @@ config :contacts_service, Contacts.Repo,
   database: "contacts_service_repo",
   username: "postgres",
   password: "postgres",
-  hostname: "localhost"
+  hostname: "localhost",
+  page_size: 100
 
 config :contacts_service, ecto_repos: [Contacts.Repo]

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,7 @@ config :contacts_service, Contacts.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  page_size: 4
 
 config :contacts_service, ecto_repos: [Contacts.Repo]

--- a/lib/contacts/repo.ex
+++ b/lib/contacts/repo.ex
@@ -4,10 +4,15 @@ defmodule Contacts.Repo do
     adapter: Ecto.Adapters.Postgres
     require Ecto.Query
 
-    def get_all() do
+    def get_all(page \\ 1) do
+      {:ok, conf_opt} = conf()
+      p_size = conf_opt[:page_size]
+      offset = p_size * (page - 1)
       Contacts.Contact
       |> Ecto.Query.where(active: true)
       |> Ecto.Query.order_by(:last_name)
+      |> Ecto.Query.limit(^p_size)
+      |> Ecto.Query.offset(^offset)
       |> all
     end
 
@@ -43,4 +48,6 @@ defmodule Contacts.Repo do
         delete(changeset)
       end
     end
+
+    defp conf, do: Application.fetch_env(:contacts_service, __MODULE__)
 end

--- a/lib/contacts/router.ex
+++ b/lib/contacts/router.ex
@@ -2,6 +2,7 @@ defmodule Contacts.Router do
   @moduledoc """
   Provides the basic routing of the contacts app.
   """
+  import Plug.Conn
   use Plug.Router
   require Logger
 
@@ -18,7 +19,10 @@ defmodule Contacts.Router do
   )
 
   get "/contacts" do
-    contacts = Contacts.Repo.get_all()
+    conn = fetch_query_params(conn)
+    page_string = Map.get(conn.params, "page", "1")
+    {page, _non_int} = Integer.parse(page_string)
+    contacts = Contacts.Repo.get_all(page)
     api_resp conn, 200, Poison.encode!(contacts)
   end
 


### PR DESCRIPTION
# Pagination

This pr adds a simple implementation of the pagination in the '/contacts' endpoint. For the time being, the pages are hardcoded in the config, but it could easily be changed to use a environment variable instead. 